### PR TITLE
Add perfdata.framework headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Guessed headers of non-public Apple SDK
        - `fs_usage` and `dyld_usage` now works
        - Only few defines and prototypes
 
+ - perfdata.framework
+    - perfdata/perfdata.h
+    - `ioclasscount` in IOKitTools-122 compiles and works
+    - XNU tests does not compile yet
+    - Only few defines and prototypes
+
  - liblockdown
     - lockdown.h
        - LLDB debugserver compiles

--- a/usr/include/perfdata/perfdata.h
+++ b/usr/include/perfdata/perfdata.h
@@ -1,0 +1,16 @@
+/* perfdata.h - Created by Nick Chan on 11/11/2022 */
+
+#ifndef PERFDATA_PERFDATA_H
+#define PERFDATA_PERFDATA_H
+#include <stdint.h>
+
+#define PDUNIT_CUSTOM(x) "#\"" x "\""
+
+typedef void* pdwriter_t;
+extern char* pdunit_B;
+
+void pdwriter_new_value(pdwriter_t pdWriter, const char* nameBuffer, char* pdUnit, double numd);
+void pdwriter_close(pdwriter_t pdWriter);
+pdwriter_t pdwriter_open(const char* pdFile, const char* pdName, int param_3, int param_4);
+void pdwriter_record_variable_str(pdwriter_t pdWriter, char *key, const char *valueBuf);
+#endif


### PR DESCRIPTION
- perfdata/perfdata.h
- `ioclasscount` in IOKitTools-122 compiles and works
- XNU tests does not compile yet
- Only few defines and prototypes